### PR TITLE
Container for integration tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+.git/
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+*.egg-info/
+build/
+dist/
+testdata/raw/
+tycho2/
+hyg4.2/
+docs/dev/reviews/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,97 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# ── Layer 1: INDI PPA + system packages ──────────────────────────────
+# The INDI PPA uses DEB822 format with an inline GPG key.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY <<'INDI_SOURCES' /etc/apt/sources.list.d/indi.sources
+Types: deb
+URIs: https://ppa.launchpadcontent.net/mutlaqja/ppa/ubuntu
+Suites: noble
+Components: main
+Signed-By:
+ -----BEGIN PGP PUBLIC KEY BLOCK-----
+ .
+ mQINBGYzk+oBEADBRiC3rHd2QZQCyPbO8G02p2sMKa66pvJx/eQr4LPQt+RB7QJv
+ rnJjUO5A6a37Ve1uI6hKEGW91saMSFR7Va9KXZgoL3U+W+1epIGV8OCVCqvpFrzF
+ RJaYjSiXZbeJOvN1iTRj5U8/kG+HcRTYUlnhKEgwh9/2EG8i+Wu9s+ABLVvYEHFF
+ zMgX5MZHQgeBTRFctHBMpZg1bze6/a6pP5MyTQkL99MmrOnZ8PfrSZSE5x9AovJs
+ Z2EIcDctnwO0sAnFPZ82oyHD3lPcQqmQhc03GB2bWxoR/474G2sjp+azyXV+T75f
+ KZqZZ07IvrZJ68h+iRt9wm8XhagvzTV180PaS7ZAJCuTdJIJueSvB0lbetxhRlcj
+ 8uWx45ZMNW0Ncoo5pEMuTkU7sIYnmhNQzBHMovBlaeCcmKu8vGJR0RQP9g8ytfGJ
+ 87bx2aNRkgkyboSGOU3cqS6faUAWZNvAy2eOUahjuDRxvFvMnn8TyCaV3ewjLlI5
+ iLbvsQldztp31+u2cDCwxd9PdPC9+P7LzODiVtlxDAUUSNl4VVsv/CgID3wkSjCA
+ BtkVS3Kje7Pe8XGiKFB4TJo19zoiEBbtY/vmDE4y+k8Up8XFK+2krmy9AEGByy7t
+ g3L8+56VoLoRma/fS5jWipo9SWCV1GlRxnNuslxAqnq58gP3epwgCjfRDwARAQAB
+ tB5MYXVuY2hwYWQgUFBBIGZvciBKYXNlbSBNdXRsYXGJAk4EEwEKADgWIQT4HU+M
+ FpdciILXs4Mz5y1EpfLpYgUCZjOT6gIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIX
+ gAAKCRAz5y1EpfLpYk5nD/47CIBejEVPEDX1vHD/uTQMQGNfw4nAn4A54ODbOveh
+ f/GOl7g+ecLA0FMJLJuuuLeMmKdozAZua/U97DJYi3FhlvyHTz/b6k9HVSabuE3B
+ 0ssRA7wHo1Exlkpk5LATDjaFqevRhWzHwI8yc3b+oV89q3kqiLI4CETkrp5vxptY
+ EFGZjsMe9Ph8/5dLwaq9BaZKeJ3ycisP57oj4svDmiflRXZE6umjd9DLRgCNLZft
+ w5+hMWmvNxaDQEWoruC1jlhRHe5LMQkZDO8G23icrR0Xj9uYGAT2MmsBa32x1EOa
+ uDjYJafeu74H0+PjVFIxkYb3ne7EURjy8tTE96qU7MrsfJeX8WSEiWP98EUhxcD6
+ ivJIEKZNLaWOfzDmS2dQBurJO6UfAfYRgSy5qtjiugh6ktxNmvjBGpoExXuVC8BR
+ DQiZGf5JTqZtq1ES6nfWBOvT+gzGggqqNGU8uoLkqIGJyzahIK5RVTlBOhBpiWqV
+ leFNihW/1H7kr6BanxIY61n4HI7vb3LmcNAQTNmxhuCdW2cvVk14tyU9L5Wphjm+
+ ZF4sXpOakuPQ1pP76dYw6W9lhqF88RFfgdLs+ymem1zDOyz7EzXNMbTsj0YRnJyT
+ bLqQNMA9hViX9e3APnP1aG3llD6d4QL8pBicQ2h3dwLrytbA+ttLdqlRrtln/XeO
+ mw==
+ =d74M
+ -----END PGP PUBLIC KEY BLOCK-----
+INDI_SOURCES
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        indi-bin \
+        libindi1 \
+        curl \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Layer 2: ASTAP CLI ───────────────────────────────────────────────
+RUN wget -q -O /tmp/astap_amd64.deb \
+        "https://sourceforge.net/projects/astap-program/files/linux_installer/astap_amd64.deb/download" \
+    && (dpkg -i /tmp/astap_amd64.deb \
+        || (apt-get update && apt-get -f install -y --no-install-recommends \
+            && rm -rf /var/lib/apt/lists/*)) \
+    && rm /tmp/astap_amd64.deb \
+    && (astap_cli -h > /dev/null 2>&1 || true)
+
+# ── Layer 3: ASTAP D50 star database ────────────────────────────────
+RUN wget -q -O /tmp/d50_star_database.deb \
+        "https://sourceforge.net/projects/astap-program/files/star_databases/d50_star_database.deb/download" \
+    && dpkg -i /tmp/d50_star_database.deb \
+    && rm /tmp/d50_star_database.deb
+
+ENV ASTAP_DB=/opt/astap
+
+# ── Layer 4: Tycho-2 catalog (~120 MB from CDS Strasbourg) ──────────
+WORKDIR /opt/astrolabe
+COPY scripts/install-tycho2.sh scripts/install-tycho2.sh
+RUN bash scripts/install-tycho2.sh
+
+# ── Layer 5: uv + Python 3.11 + project dependencies ────────────────
+ENV PATH="/root/.local/bin:$PATH"
+RUN curl --proto =https --tlsv1.2 -LsSfO https://github.com/astral-sh/uv/releases/download/0.10.4/uv-installer.sh \
+    && echo "169fd7c68bdd40f80ab25635b1e10adfc8cef58b4935017e8560c87639d4544c uv-installer.sh" | sha256sum -c - \
+    && sh uv-installer.sh \
+    && rm uv-installer.sh
+
+COPY pyproject.toml uv.lock ./
+RUN uv venv --python 3.11 .venv \
+    && uv sync --extra dev --extra tools
+
+# ── Layer 6: Application code ───────────────────────────────────────
+# .dockerignore excludes tycho2/, so COPY won't overwrite downloaded data
+COPY . .
+
+# ── Environment ─────────────────────────────────────────────────────
+ENV ASTROLABE_INDI_INTEGRATION=1
+ENV ASTAP_CLI=astap_cli
+
+ENTRYPOINT ["scripts/integration-entrypoint.sh"]
+CMD ["--integration"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.x
+
 FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -45,24 +47,24 @@ Signed-By:
  -----END PGP PUBLIC KEY BLOCK-----
 INDI_SOURCES
 
+ARG INDI_VERSION=2.1.9+202602201352~ubuntu24.04.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        indi-bin \
-        libindi1 \
+        indi-bin=${INDI_VERSION} \
+        libindi1=${INDI_VERSION} \
         curl \
-        wget \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Layer 2: ASTAP CLI ───────────────────────────────────────────────
-RUN wget -q -O /tmp/astap_amd64.deb \
+RUN curl -fSL -o /tmp/astap_amd64.deb \
         "https://sourceforge.net/projects/astap-program/files/linux_installer/astap_amd64.deb/download" \
     && (dpkg -i /tmp/astap_amd64.deb \
         || (apt-get update && apt-get -f install -y --no-install-recommends \
             && rm -rf /var/lib/apt/lists/*)) \
     && rm /tmp/astap_amd64.deb \
-    && (astap_cli -h > /dev/null 2>&1 || true)
+    && astap_cli -h > /dev/null 2>&1
 
 # ── Layer 3: ASTAP D50 star database ────────────────────────────────
-RUN wget -q -O /tmp/d50_star_database.deb \
+RUN curl -fSL -o /tmp/d50_star_database.deb \
         "https://sourceforge.net/projects/astap-program/files/star_databases/d50_star_database.deb/download" \
     && dpkg -i /tmp/d50_star_database.deb \
     && rm /tmp/d50_star_database.deb
@@ -88,6 +90,7 @@ RUN uv venv --python 3.11 .venv \
 # ── Layer 6: Application code ───────────────────────────────────────
 # .dockerignore excludes tycho2/, so COPY won't overwrite downloaded data
 COPY . .
+RUN chmod +x scripts/integration-entrypoint.sh
 
 # ── Environment ─────────────────────────────────────────────────────
 ENV ASTROLABE_INDI_INTEGRATION=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.x
+# syntax=docker/dockerfile:1
 
 FROM ubuntu:24.04
 
@@ -49,26 +49,25 @@ INDI_SOURCES
 
 ARG INDI_VERSION=2.1.9+202602201352~ubuntu24.04.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl \
         indi-bin=${INDI_VERSION} \
         libindi1=${INDI_VERSION} \
-        curl \
+        unzip \
     && rm -rf /var/lib/apt/lists/*
 
-# ── Layer 2: ASTAP CLI ───────────────────────────────────────────────
-RUN curl -fSL -o /tmp/astap_amd64.deb \
-        "https://sourceforge.net/projects/astap-program/files/linux_installer/astap_amd64.deb/download" \
-    && (dpkg -i /tmp/astap_amd64.deb \
-        || (apt-get update && apt-get -f install -y --no-install-recommends \
-            && rm -rf /var/lib/apt/lists/*)) \
-    && rm /tmp/astap_amd64.deb \
-    && astap_cli -h > /dev/null 2>&1
+# ── Layer 2: ASTAP CLI ──────────────────────────────────────────────
+RUN curl -fSL -o astap_cli_amd64.zip \
+        "https://sourceforge.net/projects/astap-program/files/linux_installer/astap_command-line_version_Linux_amd64.zip/download" \
+    && echo "fca72cff7cf7db2811262710d53e88242d6ef2e74eac444fef95b73244f37e0f astap_cli_amd64.zip" | sha256sum -c - \
+    && unzip astap_cli_amd64.zip -d /usr/bin/ \
+    && rm astap_cli_amd64.zip
 
-# ── Layer 3: ASTAP D50 star database ────────────────────────────────
-RUN curl -fSL -o /tmp/d50_star_database.deb \
-        "https://sourceforge.net/projects/astap-program/files/star_databases/d50_star_database.deb/download" \
-    && dpkg -i /tmp/d50_star_database.deb \
-    && rm /tmp/d50_star_database.deb
-
+# ── Layer 3: ASTAP D05 star database ────────────────────────────────
+RUN curl -fSL -o d05_star_database.deb \
+        "https://sourceforge.net/projects/astap-program/files/star_databases/d05_star_database.deb/download" \
+    && echo "e00b276e86c5673aef862d4fa093e739bd58cad267af916756409770fd0bd8eb d05_star_database.deb" | sha256sum -c - \
+    && dpkg -i d05_star_database.deb \
+    && rm d05_star_database.deb
 ENV ASTAP_DB=/opt/astap
 
 # ── Layer 4: Tycho-2 catalog (~120 MB from CDS Strasbourg) ──────────
@@ -78,7 +77,7 @@ RUN bash scripts/install-tycho2.sh
 
 # ── Layer 5: uv + Python 3.11 + project dependencies ────────────────
 ENV PATH="/root/.local/bin:$PATH"
-RUN curl --proto =https --tlsv1.2 -LsSfO https://github.com/astral-sh/uv/releases/download/0.10.4/uv-installer.sh \
+RUN curl --proto "=https" --tlsv1.2 -LsSfO https://github.com/astral-sh/uv/releases/download/0.10.4/uv-installer.sh \
     && echo "169fd7c68bdd40f80ab25635b1e10adfc8cef58b4935017e8560c87639d4544c uv-installer.sh" | sha256sum -c - \
     && sh uv-installer.sh \
     && rm uv-installer.sh

--- a/astrolabe/indi/client.py
+++ b/astrolabe/indi/client.py
@@ -151,6 +151,33 @@ class IndiClient:
                 raise
             logging.warning(f"Could not set vector {spec} (may be unavailable): {e}")
 
+    def snapshot(self, device: str, *, timeout_s: float = 2.0) -> dict[str, str]:
+        """Fetch all property values and states for a device in one query."""
+        cp = subprocess.run(
+            [
+                "indi_getprop",
+                "-h",
+                self.host,
+                "-p",
+                str(self.port),
+                "-t",
+                str(timeout_s),
+                f"{device}.*.*",
+                f"{device}.*._STATE",
+            ],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        result: dict[str, str] = {}
+        for line in cp.stdout.splitlines():
+            eq = line.find("=")
+            if eq < 0:
+                continue
+            result[line[:eq]] = line[eq + 1 :]
+        return result
+
     def wait_for_device(self, device: str, *, timeout_s: float = 10.0) -> None:
         deadline = time.time() + timeout_s
         last = None

--- a/astrolabe/mount/indi.py
+++ b/astrolabe/mount/indi.py
@@ -138,56 +138,42 @@ class IndiMountBackend(MountBackend):
         if not self._connected:
             self.connect()
 
-        # Determine coordinate property
-        has_jnow = self._client.has_prop(f"{self.device}.EQUATORIAL_EOD_COORD.RA")
-        has_j2000 = self._client.has_prop(f"{self.device}.EQUATORIAL_COORD.RA")
+        snap = self._client.snapshot(self.device)
+        now_utc = datetime.datetime.now(datetime.timezone.utc)
+
+        jnow_ra_key = f"{self.device}.EQUATORIAL_EOD_COORD.RA"
+        j2000_ra_key = f"{self.device}.EQUATORIAL_COORD.RA"
+        has_jnow = jnow_ra_key in snap
+        has_j2000 = j2000_ra_key in snap
 
         ra_rad = None
         dec_rad = None
-        now_utc = datetime.datetime.now(datetime.timezone.utc)
 
         if has_jnow:
-            ra_str = self._client.getprop_value(
-                f"{self.device}.EQUATORIAL_EOD_COORD.RA"
+            ra_jnow = _hours_to_rad(float(snap[jnow_ra_key]))
+            dec_jnow = _degrees_to_rad(
+                float(snap[f"{self.device}.EQUATORIAL_EOD_COORD.DEC"])
             )
-            dec_str = self._client.getprop_value(
-                f"{self.device}.EQUATORIAL_EOD_COORD.DEC"
-            )
-            ra_jnow = _hours_to_rad(float(ra_str))
-            dec_jnow = _degrees_to_rad(float(dec_str))
             ra_rad, dec_rad = jnow_to_icrs(ra_jnow, dec_jnow, now_utc)
         elif has_j2000:
-            ra_str = self._client.getprop_value(f"{self.device}.EQUATORIAL_COORD.RA")
-            dec_str = self._client.getprop_value(f"{self.device}.EQUATORIAL_COORD.DEC")
-            ra_rad = _hours_to_rad(float(ra_str))
-            dec_rad = _degrees_to_rad(float(dec_str))
-
-        # Tracking state
-        tracking = False
-        if self._client.has_prop(f"{self.device}.TELESCOPE_TRACK_STATE.TRACK_ON"):
-            track_on = self._client.getprop_value(
-                f"{self.device}.TELESCOPE_TRACK_STATE.TRACK_ON"
+            ra_rad = _hours_to_rad(float(snap[j2000_ra_key]))
+            dec_rad = _degrees_to_rad(
+                float(snap[f"{self.device}.EQUATORIAL_COORD.DEC"])
             )
-            tracking = track_on.lower() == _INDI_ON.lower()
 
-        # Slewing state: observe EQUATORIAL_EOD_COORD (or EQUATORIAL_COORD) property state.
-        # The property state will be "Busy" during a slew operation.
+        track_key = f"{self.device}.TELESCOPE_TRACK_STATE.TRACK_ON"
+        tracking = snap.get(track_key, "").lower() == _INDI_ON.lower()
+
         slewing = False
         if has_jnow:
-            coord_prop = f"{self.device}.EQUATORIAL_EOD_COORD"
+            state_key = f"{self.device}.EQUATORIAL_EOD_COORD._STATE"
         elif has_j2000:
-            coord_prop = f"{self.device}.EQUATORIAL_COORD"
+            state_key = f"{self.device}.EQUATORIAL_COORD._STATE"
         else:
-            coord_prop = None
+            state_key = None
 
-        if coord_prop is not None:
-            try:
-                prop_state = self._client.getprop_state(coord_prop)
-                slewing = prop_state.lower() == _INDI_BUSY.lower()
-            except Exception:
-                logger.debug(
-                    "Failed to read slew state for %s", coord_prop, exc_info=True
-                )
+        if state_key is not None:
+            slewing = snap.get(state_key, "").lower() == _INDI_BUSY.lower()
 
         return MountState(
             connected=True,

--- a/docs/dev/plan_indi_snapshot.md
+++ b/docs/dev/plan_indi_snapshot.md
@@ -1,0 +1,345 @@
+# INDI Client Snapshot Query Plan
+
+Goal: reduce TCP connection churn between `IndiClient` and `indiserver` by adding a batch-query method that fetches all device properties in a single `indi_getprop` invocation, and refactoring `IndiMountBackend.get_state()` to use it.
+
+Date: 2026-02-23
+
+---
+
+## 1. Motivation
+
+### 1.1 The problem
+
+`IndiClient` communicates with `indiserver` by spawning a new `indi_getprop` or `indi_setprop` subprocess for every operation. Each subprocess opens a TCP connection, sends its query, reads the response, and exits — closing the socket.
+
+When the subprocess exits, the OS tears down the TCP socket. If `indiserver` is still pushing property updates to that client, the server's `read()` hits a closed socket and logs:
+
+```
+Client 9: read: Connection reset by peer
+```
+
+These messages are harmless but noisy. In the integration test container they obscure real output and are confusing.
+
+### 1.2 Scale of the problem
+
+A single `IndiMountBackend.get_state()` call currently makes **7 sequential subprocess invocations**:
+
+| # | Method | Query |
+|---|--------|-------|
+| 1 | `has_prop` | `EQUATORIAL_EOD_COORD.RA` |
+| 2 | `has_prop` | `EQUATORIAL_COORD.RA` |
+| 3 | `getprop_value` | `EQUATORIAL_EOD_COORD.RA` |
+| 4 | `getprop_value` | `EQUATORIAL_EOD_COORD.DEC` |
+| 5 | `has_prop` | `TELESCOPE_TRACK_STATE.TRACK_ON` |
+| 6 | `getprop_value` | `TELESCOPE_TRACK_STATE.TRACK_ON` |
+| 7 | `getprop_state` | `EQUATORIAL_EOD_COORD` |
+
+The `test_indi_mount_slew_and_state` integration test calls `get_state()` in a polling loop with 0.5 s sleeps, plus additional `getprop_value` calls for `TARGET_EOD_COORD`. Over a 60-second slew timeout this produces **hundreds** of short-lived TCP connections, each generating a "Connection reset by peer" log line.
+
+`slew_to()` adds another 5+ `has_prop` calls for capability probing. Other methods (`sync`, `pulse_guide`, `set_tracking`) follow the same pattern.
+
+### 1.3 INDI scripting tools support batch queries
+
+The `indi_getprop` documentation (see `indi_scripting.html`) states:
+
+> Any component may be `"*"` to match all.
+
+A single wildcard query like `"Telescope Simulator.*.*"` returns **all** element values for the device in one TCP connection. Output format without `-1`:
+
+```
+Telescope Simulator.EQUATORIAL_EOD_COORD.RA=6.0
+Telescope Simulator.EQUATORIAL_EOD_COORD.DEC=45.0
+Telescope Simulator.TELESCOPE_TRACK_STATE.TRACK_ON=On
+Telescope Simulator.CONNECTION.CONNECT=On
+...
+```
+
+Additionally, `indi_getprop` supports a `_STATE` pseudo-element:
+
+> Set element to `_STATE` to report state.
+
+So `"Telescope Simulator.*._STATE"` returns property states in one invocation:
+
+```
+Telescope Simulator.EQUATORIAL_EOD_COORD._STATE=Ok
+Telescope Simulator.TELESCOPE_TRACK_STATE._STATE=Idle
+...
+```
+
+`indi_getprop` accepts multiple query arguments, so both can be combined into a single invocation:
+
+```
+indi_getprop "Telescope Simulator.*.*" "Telescope Simulator.*._STATE"
+```
+
+This yields all element values **and** all property states in one TCP connection.
+
+---
+
+## 2. Design
+
+### 2.1 New method: `IndiClient.snapshot`
+
+Add a single method to `IndiClient` that returns a parsed snapshot of all properties for a given device.
+
+```python
+def snapshot(
+    self, device: str, *, timeout_s: float = 2.0
+) -> dict[str, str]:
+```
+
+Invokes:
+
+```
+indi_getprop -h HOST -p PORT -t TIMEOUT "DEVICE.*.*" "DEVICE.*._STATE"
+```
+
+Parses each output line as `key=value` (splitting on the first `=`) and returns a flat dict:
+
+```python
+{
+    "Telescope Simulator.EQUATORIAL_EOD_COORD.RA": "6.0",
+    "Telescope Simulator.EQUATORIAL_EOD_COORD.DEC": "45.0",
+    "Telescope Simulator.EQUATORIAL_EOD_COORD._STATE": "Ok",
+    "Telescope Simulator.TELESCOPE_TRACK_STATE.TRACK_ON": "On",
+    "Telescope Simulator.TELESCOPE_TRACK_STATE._STATE": "Idle",
+    ...
+}
+```
+
+The `-1` flag is **not** used (it is only valid for single-result queries).
+
+### 2.2 Refactor `IndiMountBackend.get_state`
+
+Replace the 7 sequential subprocess calls with:
+
+1. One `self._client.snapshot(self.device)` call.
+2. Pure dict lookups for `has_prop`, `getprop_value`, and `getprop_state` equivalents.
+
+```python
+def get_state(self) -> MountState:
+    if not self._connected:
+        self.connect()
+
+    snap = self._client.snapshot(self.device)
+    now_utc = datetime.datetime.now(datetime.timezone.utc)
+
+    ra_key_jnow = f"{self.device}.EQUATORIAL_EOD_COORD.RA"
+    ra_key_j2000 = f"{self.device}.EQUATORIAL_COORD.RA"
+    # ... dict lookups instead of subprocess calls ...
+```
+
+This reduces `get_state()` from 7 TCP connections to **1**.
+
+### 2.3 Scope limitation
+
+This plan **only** changes the read path (`get_state`). Write operations (`setprop`, `setprop_multi`, `setprop_vector`) remain as individual subprocess calls — they are inherently one-shot commands and cannot be batched.
+
+The `has_prop` calls in `slew_to()`, `sync()`, and other write-oriented methods are not changed in this plan. They are candidates for future optimisation (e.g., caching capability probing results at `connect()` time, as suggested in `plan_indi.md` §4.2). That is a separate concern.
+
+### 2.4 Design decisions
+
+- **No caching / staleness**: `snapshot()` is a fresh query each time it is called. No state is held between calls. This preserves the stateless, simple nature of the current `IndiClient`.
+- **No new dependencies**: continues to use `subprocess.run` and `indi_getprop`.
+- **Backwards compatible**: existing `has_prop`, `getprop_value`, `getprop_state` methods remain unchanged. Other callers (camera backend, scripts) continue to work.
+- **Wildcard safety**: the device name is interpolated into the query string. Device names with glob metacharacters are not expected in practice. No shell expansion occurs because `subprocess.run` is called with a list (not a shell string).
+
+---
+
+## 3. Files modified
+
+| File | Change |
+|------|--------|
+| `astrolabe/indi/client.py` | Add `snapshot()` method |
+| `astrolabe/mount/indi.py` | Refactor `get_state()` to use `snapshot()` |
+| `tests/mount/test_indi_mount.py` | Update unit tests that verify `get_state()` behaviour |
+
+No new files are created. No files are deleted.
+
+---
+
+## 4. `IndiClient.snapshot` implementation
+
+```python
+def snapshot(self, device: str, *, timeout_s: float = 2.0) -> dict[str, str]:
+    """Fetch all property values and states for a device in one query."""
+    cp = subprocess.run(
+        [
+            "indi_getprop",
+            "-h", self.host,
+            "-p", str(self.port),
+            "-t", str(timeout_s),
+            f"{device}.*.*",
+            f"{device}.*._STATE",
+        ],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    result: dict[str, str] = {}
+    for line in cp.stdout.splitlines():
+        eq = line.find("=")
+        if eq < 0:
+            continue
+        result[line[:eq]] = line[eq + 1:]
+    return result
+```
+
+Notes:
+- `check=False` because exit code 1 means "at least one query returned nothing" — the `_STATE` query may not match all properties, which is acceptable.
+- Lines without `=` (malformed output) are silently skipped.
+
+---
+
+## 5. `get_state` refactored implementation
+
+```python
+def get_state(self) -> MountState:
+    if not self._connected:
+        self.connect()
+
+    snap = self._client.snapshot(self.device)
+    now_utc = datetime.datetime.now(datetime.timezone.utc)
+
+    jnow_ra_key = f"{self.device}.EQUATORIAL_EOD_COORD.RA"
+    j2000_ra_key = f"{self.device}.EQUATORIAL_COORD.RA"
+    has_jnow = jnow_ra_key in snap
+    has_j2000 = j2000_ra_key in snap
+
+    ra_rad = None
+    dec_rad = None
+
+    if has_jnow:
+        ra_jnow = _hours_to_rad(float(snap[jnow_ra_key]))
+        dec_jnow = _degrees_to_rad(
+            float(snap[f"{self.device}.EQUATORIAL_EOD_COORD.DEC"])
+        )
+        ra_rad, dec_rad = jnow_to_icrs(ra_jnow, dec_jnow, now_utc)
+    elif has_j2000:
+        ra_rad = _hours_to_rad(float(snap[j2000_ra_key]))
+        dec_rad = _degrees_to_rad(
+            float(snap[f"{self.device}.EQUATORIAL_COORD.DEC"])
+        )
+
+    track_key = f"{self.device}.TELESCOPE_TRACK_STATE.TRACK_ON"
+    tracking = snap.get(track_key, "").lower() == _INDI_ON.lower()
+
+    slewing = False
+    if has_jnow:
+        state_key = f"{self.device}.EQUATORIAL_EOD_COORD._STATE"
+    elif has_j2000:
+        state_key = f"{self.device}.EQUATORIAL_COORD._STATE"
+    else:
+        state_key = None
+
+    if state_key is not None:
+        slewing = snap.get(state_key, "").lower() == _INDI_BUSY.lower()
+
+    return MountState(
+        connected=True,
+        ra_rad=ra_rad,
+        dec_rad=dec_rad,
+        tracking=tracking,
+        slewing=slewing,
+        timestamp_utc=now_utc,
+    )
+```
+
+---
+
+## 6. Test changes
+
+### 6.1 Existing unit tests affected
+
+The following tests patch `IndiClient` methods called by `get_state()`:
+
+- `test_get_state_jnow`
+- `test_get_state_detects_slewing`
+- `test_get_state_j2000`
+- `test_get_state_auto_connects`
+
+These currently patch `has_prop`, `getprop_value`, and `getprop_state`. They must be updated to patch `snapshot` instead, providing a dict return value.
+
+### 6.2 Updated test pattern
+
+Before (current):
+```python
+def test_get_state_jnow(mount):
+    mount._connected = True
+    with (
+        patch("...IndiClient.has_prop") as mock_has_prop,
+        patch("...IndiClient.getprop_value") as mock_getprop,
+        patch("...IndiClient.getprop_state") as mock_getprop_state,
+        patch("...jnow_to_icrs") as mock_jnow_to_icrs,
+    ):
+        # ... configure side_effect functions for each mock ...
+```
+
+After:
+```python
+def test_get_state_jnow(mount):
+    mount._connected = True
+    snap = {
+        "Telescope Simulator.EQUATORIAL_EOD_COORD.RA": "6.0",
+        "Telescope Simulator.EQUATORIAL_EOD_COORD.DEC": "45.0",
+        "Telescope Simulator.EQUATORIAL_EOD_COORD._STATE": "Ok",
+        "Telescope Simulator.TELESCOPE_TRACK_STATE.TRACK_ON": "On",
+    }
+    with (
+        patch("...IndiClient.snapshot", return_value=snap),
+        patch("...jnow_to_icrs") as mock_jnow_to_icrs,
+    ):
+        # ... same assertions, simpler setup ...
+```
+
+### 6.3 New unit test for `snapshot`
+
+Add a test in `tests/indi/test_client.py` (or within the mount test file) that verifies `snapshot()` correctly parses multi-line `indi_getprop` output into a dict.
+
+### 6.4 Integration tests unchanged
+
+The integration tests (`test_indi_mount_slew_and_state`, `test_indi_mount_connect_and_state`) are not modified. They exercise the real code path and will automatically benefit from the reduced connection churn.
+
+---
+
+## 7. Impact on connection churn
+
+### Before
+
+| Operation | Subprocess calls |
+|-----------|-----------------|
+| `get_state()` | 7 |
+| `get_state()` in slew poll (×~20 iterations) | 140 |
+| `slew_to()` | ~10 |
+| **Total for `test_indi_mount_slew_and_state`** | **~150+** |
+
+### After
+
+| Operation | Subprocess calls |
+|-----------|-----------------|
+| `get_state()` | 1 |
+| `get_state()` in slew poll (×~20 iterations) | 20 |
+| `slew_to()` (unchanged) | ~10 |
+| **Total for `test_indi_mount_slew_and_state`** | **~30** |
+
+**~80% reduction** in TCP connections opened and torn down. Proportional reduction in "Connection reset by peer" log messages from `indiserver`.
+
+---
+
+## 8. Risks & mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Wildcard query returns too much data | Slower parse for devices with many properties | Telescope simulators have ~30-50 properties. Parse is trivial. |
+| `_STATE` pseudo-element not supported on older INDI | Missing state keys in snapshot dict | `snap.get(state_key, "")` defaults gracefully; slewing defaults to `False`. |
+| Device name contains glob metacharacters | Query matches wrong device | Not expected in practice. `subprocess.run` with list args avoids shell expansion. |
+| Snapshot is stale by the time values are read | Coordinates slightly out of date | Same staleness window as current sequential calls (actually better — all values are from the same point in time). |
+
+---
+
+## 9. Future work (out of scope)
+
+- **Capability caching at connect time**: `slew_to()`, `sync()`, and other methods probe `has_prop` on every call. These capabilities don't change during a session. Caching them at `connect()` time (as suggested in `plan_indi.md` §4.2) would further reduce churn. This is a separate concern.
+- **Entrypoint stderr suppression**: redirecting `indiserver` stderr to a log file (Option B from the earlier analysis) would eliminate remaining noise from `setprop` calls. Complementary to this change.
+- **Persistent INDI XML client**: replacing subprocess-per-call with a long-lived TCP connection is the architectural end-state but is a much larger undertaking.

--- a/docs/dev/plan_integration_container.md
+++ b/docs/dev/plan_integration_container.md
@@ -12,7 +12,7 @@ Date: 2026-02-22
 |---|---|---|---|
 | `test_indi_mount_slew_and_state` | `tests/mount/test_indi_mount.py` | `indiserver`, `indi_simulator_telescope`, `indi_getprop`, `indi_setprop` | None |
 | `test_indi_mount_connect_and_state` | `tests/mount/test_indi_mount.py` | Same as above | None |
-| `test_astap_solve_integration_synthetic` | `tests/solver/test_astap.py` | `astap_cli` | D50 star database, Tycho-2 catalog → synthetic FITS |
+| `test_astap_solve_integration_synthetic` | `tests/solver/test_astap.py` | `astap_cli`, `indiserver`, `indi_simulator_ccd` | D50 star database, Tycho-2 catalog → synthetic FITS |
 
 ---
 
@@ -45,7 +45,7 @@ Base image: `ubuntu:24.04` (Noble — matches the INDI PPA `Suites: noble`).
 1. **System packages + INDI PPA**
    - Install `ca-certificates` first (needed for PPA HTTPS).
    - Write the INDI PPA `.sources` file with embedded GPG key to `/etc/apt/sources.list.d/indi.sources`.
-   - Install: `indi-bin`, `libindi1`, `curl`, `wget`, `ca-certificates`. Python is managed by `uv` (see layer 5).
+   - Install: `indi-bin`, `libindi1`, `curl`, `ca-certificates`. Python is managed by `uv` (see layer 5).
 
 2. **ASTAP CLI** (pinned version)
    - Download `.deb` from SourceForge (`astap_amd64.deb`).
@@ -94,7 +94,7 @@ Base image: `ubuntu:24.04` (Noble — matches the INDI PPA `Suites: noble`).
 ## 5. `scripts/integration-entrypoint.sh`
 
 1. Trap `EXIT` to kill `indiserver` on any exit.
-2. Start `indiserver indi_simulator_telescope` in background.
+2. Start `indiserver indi_simulator_telescope indi_simulator_ccd` in background. The CCD simulator is needed by solver integration tests that capture synthetic FITS frames.
 3. Poll `indi_getprop -1 -t 1 "Telescope Simulator.CONNECTION.CONNECT"` until it returns `Off` (device exists but is not yet connected), with a 15 s timeout (30 iterations × 0.5 s).
 4. `exec uv run pytest "$@"` — replaces the shell process with pytest. The `--integration` flag is supplied via `CMD` in the Dockerfile, so it appears in `$@` by default.
 
@@ -128,7 +128,7 @@ docker run --rm astrolabe-integration --integration -v
 | Risk | Impact | Mitigation |
 |---|---|---|
 | ASTAP SourceForge URL changes | Build fails | Pin exact URL with version. Add clear error message. |
-| Tycho-2 CDS mirror slow/down | Build very slow or fails | `wget -c` retries. Layer is cached after first build. |
+| Tycho-2 CDS mirror slow/down | Build very slow or fails | `curl -C -` retries. Layer is cached after first build. |
 | INDI PPA key rotation | `apt-get update` fails | GPG key embedded in `.sources` file; update Dockerfile when rotated. |
 | Image size (~1–2 GB) | Slow CI pulls | Acceptable for self-contained integration. Data layers are cached. |
 | `indiserver` startup race | Mount tests fail intermittently | Polling loop with timeout in entrypoint ensures readiness. |

--- a/docs/dev/plan_integration_container.md
+++ b/docs/dev/plan_integration_container.md
@@ -127,7 +127,7 @@ docker run --rm astrolabe-integration --integration -v
 | Risk | Impact | Mitigation |
 |---|---|---|
 | ASTAP SourceForge URL changes | Build fails | Pin exact URL with version. Add clear error message. |
-| Tycho-2 CDS mirror slow/down | Build very slow or fails | `curl -C -` retries. Layer is cached after first build. |
+| Tycho-2 CDS mirror slow/down | Build very slow or fails | `curl -C - --retry 5 --retry-all-errors --retry-delay 3`. Layer is cached after first build. |
 | INDI PPA key rotation | `apt-get update` fails | GPG key embedded in `.sources` file; update Dockerfile when rotated. |
 | Image size (~1–2 GB) | Slow CI pulls | Acceptable for self-contained integration. Data layers are cached. |
 | `indiserver` startup race | Mount tests fail intermittently | Polling loop with timeout in entrypoint ensures readiness. |

--- a/docs/dev/plan_integration_container.md
+++ b/docs/dev/plan_integration_container.md
@@ -1,0 +1,132 @@
+# Integration Test Container Plan
+
+Goal: create a self-contained Docker image that runs the full integration test suite for the INDI mount backend and ASTAP solver backend, including all system dependencies, star databases, and an entrypoint that orchestrates `indiserver` startup before executing `pytest --integration`.
+
+Date: 2026-02-22
+
+---
+
+## 1. Target integration tests
+
+| Test | File | System dependencies | Data dependencies |
+|---|---|---|---|
+| `test_indi_mount_slew_and_state` | `tests/mount/test_indi_mount.py` | `indiserver`, `indi_simulator_telescope`, `indi_getprop`, `indi_setprop` | None |
+| `test_indi_mount_connect_and_state` | `tests/mount/test_indi_mount.py` | Same as above | None |
+| `test_astap_solve_integration_synthetic` | `tests/solver/test_astap.py` | `astap_cli` | D50 star database, Tycho-2 catalog → synthetic FITS |
+
+---
+
+## 2. Files to create
+
+| File | Purpose |
+|---|---|
+| `Dockerfile` | Container image definition |
+| `.dockerignore` | Exclude build artifacts from context |
+| `scripts/integration-entrypoint.sh` | Entrypoint: starts INDI, runs tests |
+
+No existing files are modified.
+
+---
+
+## 3. `.dockerignore`
+
+Excludes `.venv/`, `__pycache__/`, `.git/`, `.pytest_cache/`, `.ruff_cache/`, `testdata/raw/`, `tycho2/`, `hyg4.2/`, `build/`, `dist/`, `*.egg-info/`, `docs/dev/reviews/`.
+
+Rationale: Tycho-2 data is downloaded inside the container. Excluding `.git` and `.venv` prevents multi-MB waste in the build context.
+
+---
+
+## 4. Dockerfile
+
+Base image: `ubuntu:24.04` (Noble — matches the INDI PPA `Suites: noble`).
+
+### Layer structure (top to bottom)
+
+1. **System packages + INDI PPA**
+   - Write the INDI PPA `.sources` file with embedded GPG key to `/etc/apt/sources.list.d/indi.sources`.
+   - Install: `indi-bin`, `libindi-dev`, `libindi1`, `python3.11`, `python3.11-venv`, `python3-pip`, `wget`, `ca-certificates`.
+
+2. **ASTAP CLI** (pinned version)
+   - Download `.deb` from SourceForge (`astap_amd64.deb`).
+   - Install with `dpkg -i` + `apt-get -f install -y`.
+   - Verify: `astap_cli -h`.
+
+3. **ASTAP D50 star database**
+   - Download D50 `.deb` from SourceForge.
+   - Install with `dpkg -i`.
+   - Set `ASTAP_DB` env var to installed path.
+
+4. **Tycho-2 catalog**
+   - Copy and run `scripts/install-tycho2.sh` (~120 MB download from CDS Strasbourg).
+   - Installed at `/opt/astrolabe/tycho2/`.
+
+5. **Python environment**
+   - Copy `pyproject.toml` + `uv.lock` first (layer caching).
+   - Install `uv` via pip, run `uv sync --extra dev --extra tools`.
+
+6. **Application code**
+   - `COPY . /opt/astrolabe/`
+   - `WORKDIR /opt/astrolabe`
+
+7. **Environment variables**
+   ```
+   ASTROLABE_INDI_INTEGRATION=1
+   ASTAP_CLI=astap_cli
+   ASTAP_DB=/opt/astap
+   ```
+
+8. **Entrypoint**
+   - `ENTRYPOINT ["scripts/integration-entrypoint.sh"]`
+   - `CMD ["--integration"]`
+
+### Design decisions
+
+- **Single stage:** all dependencies are runtime (INDI, ASTAP, Python), so multi-stage would not save image size.
+- **Layer ordering:** system pkgs → ASTAP → database → Tycho-2 → Python deps → app code. Maximises Docker layer cache reuse; the expensive download layers rarely change.
+- **No `USER` switch:** INDI simulators and ASTAP run as root in a disposable CI container. No secrets involved.
+- **Pinned versions:** ASTAP `.deb` pinned to a specific release for reproducible builds.
+
+---
+
+## 5. `scripts/integration-entrypoint.sh`
+
+1. Start `indiserver indi_simulator_telescope` in background.
+2. Poll `indi_getprop` until the simulator device appears (15 s timeout).
+3. Run `uv run pytest --integration "$@"`.
+4. Propagate pytest exit code.
+5. Trap `EXIT` to kill `indiserver`.
+
+The solver test's `synthetic_fits_path` fixture handles FITS generation internally — it symlinks `tycho2/` from the repo root and runs `gen_catalog_starfield.py` in a temp directory. The entrypoint only needs to ensure `tycho2/` exists at `/opt/astrolabe/tycho2/`.
+
+---
+
+## 6. Usage
+
+```bash
+# Build
+docker build -t astrolabe-integration .
+
+# Run all integration tests
+docker run --rm astrolabe-integration
+
+# Run only mount tests
+docker run --rm astrolabe-integration --integration tests/mount/test_indi_mount.py
+
+# Run only solver tests
+docker run --rm astrolabe-integration --integration tests/solver/test_astap.py
+
+# Verbose output
+docker run --rm astrolabe-integration --integration -v
+```
+
+---
+
+## 7. Risks & mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| ASTAP SourceForge URL changes | Build fails | Pin exact URL with version. Add clear error message. |
+| Tycho-2 CDS mirror slow/down | Build very slow or fails | `wget -c` retries. Layer is cached after first build. |
+| INDI PPA key rotation | `apt-get update` fails | GPG key embedded in `.sources` file; update Dockerfile when rotated. |
+| Image size (~1–2 GB) | Slow CI pulls | Acceptable for self-contained integration. Data layers are cached. |
+| `indiserver` startup race | Mount tests fail intermittently | Polling loop with timeout in entrypoint ensures readiness. |

--- a/docs/dev/plan_integration_container.md
+++ b/docs/dev/plan_integration_container.md
@@ -12,7 +12,7 @@ Date: 2026-02-22
 |---|---|---|---|
 | `test_indi_mount_slew_and_state` | `tests/mount/test_indi_mount.py` | `indiserver`, `indi_simulator_telescope`, `indi_getprop`, `indi_setprop` | None |
 | `test_indi_mount_connect_and_state` | `tests/mount/test_indi_mount.py` | Same as above | None |
-| `test_astap_solve_integration_synthetic` | `tests/solver/test_astap.py` | `astap_cli`, `indiserver`, `indi_simulator_ccd` | D50 star database, Tycho-2 catalog → synthetic FITS |
+| `test_astap_solve_integration_synthetic` | `tests/solver/test_astap.py` | `astap_cli`, `indiserver`, `indi_simulator_ccd` | D05 star database, Tycho-2 catalog → synthetic FITS |
 
 ---
 
@@ -43,17 +43,16 @@ Base image: `ubuntu:24.04` (Noble — matches the INDI PPA `Suites: noble`).
 ### Layer structure (top to bottom)
 
 1. **System packages + INDI PPA**
-   - Install `ca-certificates` first (needed for PPA HTTPS).
+   - First `RUN`: install `ca-certificates` (needed for PPA HTTPS).
    - Write the INDI PPA `.sources` file with embedded GPG key to `/etc/apt/sources.list.d/indi.sources`.
-   - Install: `indi-bin`, `libindi1`, `curl`, `ca-certificates`. Python is managed by `uv` (see layer 5).
+   - Second `RUN`: install `curl`, `indi-bin`, `libindi1`, `unzip`. INDI is version-pinned via a build `ARG` (e.g. `INDI_VERSION=2.1.9+…`). Python is managed by `uv` (see layer 5).
 
-2. **ASTAP CLI** (pinned version)
-   - Download `.deb` from SourceForge (`astap_amd64.deb`).
-   - Install with `dpkg -i` + `apt-get -f install -y`.
-   - Verify: `astap_cli -h`.
+2. **ASTAP CLI** (SHA-256 pinned)
+   - Download `.zip` from SourceForge (`astap_cli_amd64.zip`).
+   - Verify SHA-256 checksum, extract with `unzip -d /usr/bin/`.
 
-3. **ASTAP D50 star database**
-   - Download D50 `.deb` from SourceForge.
+3. **ASTAP D05 star database**
+   - Download D05 `.deb` from SourceForge.
    - Install with `dpkg -i`.
    - Set `ASTAP_DB` env var to installed path.
 
@@ -62,7 +61,7 @@ Base image: `ubuntu:24.04` (Noble — matches the INDI PPA `Suites: noble`).
    - Installed at `/opt/astrolabe/tycho2/`.
 
 5. **Python environment**
-   - Install `uv` via its official installer script (downloaded from GitHub with SHA-256 checksum verification, pinned to a specific release).
+   - Install `uv` via its official installer script (downloaded from GitHub with SHA-256 checksum verification, pinned to a specific release). Set `PATH` to include `/root/.local/bin` so `uv` is available in subsequent layers.
    - Copy `pyproject.toml` + `uv.lock` first (layer caching).
    - Run `uv venv --python 3.11 .venv && uv sync --extra dev --extra tools`.
 
@@ -71,7 +70,7 @@ Base image: `ubuntu:24.04` (Noble — matches the INDI PPA `Suites: noble`).
    - `COPY . .`
 
 7. **Environment variables**
-   - `ASTAP_DB=/opt/astap` is set immediately after the D50 database install (layer 3) so it is available during subsequent build steps.
+   - `ASTAP_DB=/opt/astap` is set immediately after the D05 database install (layer 3) so it is available during subsequent build steps.
    - The remaining variables are set after application code is copied:
    ```
    ASTROLABE_INDI_INTEGRATION=1
@@ -87,7 +86,7 @@ Base image: `ubuntu:24.04` (Noble — matches the INDI PPA `Suites: noble`).
 - **Single stage:** all dependencies are runtime (INDI, ASTAP, Python), so multi-stage would not save image size.
 - **Layer ordering:** system pkgs → ASTAP → database → Tycho-2 → Python deps → app code. Maximises Docker layer cache reuse; the expensive download layers rarely change.
 - **No `USER` switch:** INDI simulators and ASTAP run as root in a disposable CI container. No secrets involved.
-- **Pinned versions:** ASTAP `.deb` pinned to a specific release for reproducible builds. `uv` installer pinned by version and SHA-256 checksum.
+- **Pinned versions:** INDI is version-pinned via a build `ARG`. ASTAP CLI `.zip` is SHA-256 pinned for reproducible builds (the SourceForge URL is not versioned). `uv` installer pinned by version and SHA-256 checksum.
 
 ---
 

--- a/docs/dev/plan_integration_container.md
+++ b/docs/dev/plan_integration_container.md
@@ -30,7 +30,7 @@ No existing files are modified.
 
 ## 3. `.dockerignore`
 
-Excludes `.venv/`, `__pycache__/`, `.git/`, `.pytest_cache/`, `.ruff_cache/`, `testdata/raw/`, `tycho2/`, `hyg4.2/`, `build/`, `dist/`, `*.egg-info/`, `docs/dev/reviews/`.
+Excludes `.venv/`, `__pycache__/`, `*.pyc`, `*.pyo`, `.git/`, `.pytest_cache/`, `.ruff_cache/`, `.mypy_cache/`, `testdata/raw/`, `tycho2/`, `hyg4.2/`, `build/`, `dist/`, `*.egg-info/`, `docs/dev/reviews/`.
 
 Rationale: Tycho-2 data is downloaded inside the container. Excluding `.git` and `.venv` prevents multi-MB waste in the build context.
 
@@ -43,8 +43,9 @@ Base image: `ubuntu:24.04` (Noble — matches the INDI PPA `Suites: noble`).
 ### Layer structure (top to bottom)
 
 1. **System packages + INDI PPA**
+   - Install `ca-certificates` first (needed for PPA HTTPS).
    - Write the INDI PPA `.sources` file with embedded GPG key to `/etc/apt/sources.list.d/indi.sources`.
-   - Install: `indi-bin`, `libindi-dev`, `libindi1`, `python3.11`, `python3.11-venv`, `python3-pip`, `wget`, `ca-certificates`.
+   - Install: `indi-bin`, `libindi1`, `curl`, `wget`, `ca-certificates`. Python is managed by `uv` (see layer 5).
 
 2. **ASTAP CLI** (pinned version)
    - Download `.deb` from SourceForge (`astap_amd64.deb`).
@@ -61,18 +62,20 @@ Base image: `ubuntu:24.04` (Noble — matches the INDI PPA `Suites: noble`).
    - Installed at `/opt/astrolabe/tycho2/`.
 
 5. **Python environment**
+   - Install `uv` via its official installer script (downloaded from GitHub with SHA-256 checksum verification, pinned to a specific release).
    - Copy `pyproject.toml` + `uv.lock` first (layer caching).
-   - Install `uv` via pip, run `uv sync --extra dev --extra tools`.
+   - Run `uv venv --python 3.11 .venv && uv sync --extra dev --extra tools`.
 
 6. **Application code**
-   - `COPY . /opt/astrolabe/`
-   - `WORKDIR /opt/astrolabe`
+   - `WORKDIR /opt/astrolabe` (set earlier, before Tycho-2 install)
+   - `COPY . .`
 
 7. **Environment variables**
+   - `ASTAP_DB=/opt/astap` is set immediately after the D50 database install (layer 3) so it is available during subsequent build steps.
+   - The remaining variables are set after application code is copied:
    ```
    ASTROLABE_INDI_INTEGRATION=1
    ASTAP_CLI=astap_cli
-   ASTAP_DB=/opt/astap
    ```
 
 8. **Entrypoint**
@@ -84,17 +87,16 @@ Base image: `ubuntu:24.04` (Noble — matches the INDI PPA `Suites: noble`).
 - **Single stage:** all dependencies are runtime (INDI, ASTAP, Python), so multi-stage would not save image size.
 - **Layer ordering:** system pkgs → ASTAP → database → Tycho-2 → Python deps → app code. Maximises Docker layer cache reuse; the expensive download layers rarely change.
 - **No `USER` switch:** INDI simulators and ASTAP run as root in a disposable CI container. No secrets involved.
-- **Pinned versions:** ASTAP `.deb` pinned to a specific release for reproducible builds.
+- **Pinned versions:** ASTAP `.deb` pinned to a specific release for reproducible builds. `uv` installer pinned by version and SHA-256 checksum.
 
 ---
 
 ## 5. `scripts/integration-entrypoint.sh`
 
-1. Start `indiserver indi_simulator_telescope` in background.
-2. Poll `indi_getprop` until the simulator device appears (15 s timeout).
-3. Run `uv run pytest --integration "$@"`.
-4. Propagate pytest exit code.
-5. Trap `EXIT` to kill `indiserver`.
+1. Trap `EXIT` to kill `indiserver` on any exit.
+2. Start `indiserver indi_simulator_telescope` in background.
+3. Poll `indi_getprop -1 -t 1 "Telescope Simulator.CONNECTION.CONNECT"` until it returns `Off` (device exists but is not yet connected), with a 15 s timeout (30 iterations × 0.5 s).
+4. `exec uv run pytest "$@"` — replaces the shell process with pytest. The `--integration` flag is supplied via `CMD` in the Dockerfile, so it appears in `$@` by default.
 
 The solver test's `synthetic_fits_path` fixture handles FITS generation internally — it symlinks `tycho2/` from the repo root and runs `gen_catalog_starfield.py` in a temp directory. The entrypoint only needs to ensure `tycho2/` exists at `/opt/astrolabe/tycho2/`.
 

--- a/docs/dev/plan_integration_container.md
+++ b/docs/dev/plan_integration_container.md
@@ -24,7 +24,7 @@ Date: 2026-02-22
 | `.dockerignore` | Exclude build artifacts from context |
 | `scripts/integration-entrypoint.sh` | Entrypoint: starts INDI, runs tests |
 
-No existing files are modified.
+The following existing files are modified: `scripts/install-tycho2.sh`, `astrolabe/mount/indi.py`, and `astrolabe/indi/client.py`.
 
 ---
 

--- a/scripts/install-tycho2.sh
+++ b/scripts/install-tycho2.sh
@@ -7,6 +7,6 @@ mkdir -p "$outdir"
 for i in $(seq -w 00 19); do
   curl -kfSL -C - -o "$outdir/tyc2.dat.$i.gz" "$base/tyc2.dat.$i.gz"
 done
-curl -fSL -C - -o "$outdir/ReadMe" "$base/ReadMe"
-curl -fSL -C - -o "$outdir/suppl_1.dat.gz" "$base/suppl_1.dat.gz"
-curl -fSL -C - -o "$outdir/suppl_2.dat.gz" "$base/suppl_2.dat.gz"
+curl -kfSL -C - -o "$outdir/ReadMe" "$base/ReadMe"
+curl -kfSL -C - -o "$outdir/suppl_1.dat.gz" "$base/suppl_1.dat.gz"
+curl -kfSL -C - -o "$outdir/suppl_2.dat.gz" "$base/suppl_2.dat.gz"

--- a/scripts/install-tycho2.sh
+++ b/scripts/install-tycho2.sh
@@ -4,9 +4,10 @@ set -euo pipefail
 base="https://cdsarc.u-strasbg.fr/ftp/cati/vizier/ftp/0/aliases/T/Tycho-2" # expired tls cert
 outdir="tycho2"
 mkdir -p "$outdir"
+curl_flags=( -kfSL -C - --retry 5 --retry-all-errors --retry-delay 3 )
 for i in $(seq -w 00 19); do
-  curl -kfSL -C - -o "$outdir/tyc2.dat.$i.gz" "$base/tyc2.dat.$i.gz"
+  curl "${curl_flags[@]}" -o "$outdir/tyc2.dat.$i.gz" "$base/tyc2.dat.$i.gz"
 done
-curl -kfSL -C - -o "$outdir/ReadMe" "$base/ReadMe"
-curl -kfSL -C - -o "$outdir/suppl_1.dat.gz" "$base/suppl_1.dat.gz"
-curl -kfSL -C - -o "$outdir/suppl_2.dat.gz" "$base/suppl_2.dat.gz"
+curl "${curl_flags[@]}" -o "$outdir/ReadMe" "$base/ReadMe"
+curl "${curl_flags[@]}" -o "$outdir/suppl_1.dat.gz" "$base/suppl_1.dat.gz"
+curl "${curl_flags[@]}" -o "$outdir/suppl_2.dat.gz" "$base/suppl_2.dat.gz"

--- a/scripts/install-tycho2.sh
+++ b/scripts/install-tycho2.sh
@@ -1,12 +1,12 @@
 #! /bin/bash
 set -euo pipefail
 
-base="https://cdsarc.u-strasbg.fr/ftp/cati/vizier/ftp/0/aliases/T/Tycho-2"
+base="https://cdsarc.u-strasbg.fr/ftp/cati/vizier/ftp/0/aliases/T/Tycho-2" # expired tls cert
 outdir="tycho2"
 mkdir -p "$outdir"
 for i in $(seq -w 00 19); do
-  wget -c "$base/tyc2.dat.$i.gz" --no-check-certificate -P "$outdir"
+  curl -kfSL -C - -o "$outdir/tyc2.dat.$i.gz" "$base/tyc2.dat.$i.gz"
 done
-wget -c "$base/ReadMe" --no-check-certificate -P "$outdir"
-wget -c "$base/suppl_1.dat.gz" --no-check-certificate -P "$outdir"
-wget -c "$base/suppl_2.dat.gz" --no-check-certificate -P "$outdir"
+curl -fSL -C - -o "$outdir/ReadMe" "$base/ReadMe"
+curl -fSL -C - -o "$outdir/suppl_1.dat.gz" "$base/suppl_1.dat.gz"
+curl -fSL -C - -o "$outdir/suppl_2.dat.gz" "$base/suppl_2.dat.gz"

--- a/scripts/integration-entrypoint.sh
+++ b/scripts/integration-entrypoint.sh
@@ -9,7 +9,7 @@ cleanup() {
 trap cleanup EXIT
 
 echo "[integration] Starting indiserver with telescope simulator..."
-indiserver indi_simulator_telescope &
+indiserver indi_simulator_telescope indi_simulator_ccd &
 INDI_PID=$!
 
 echo "[integration] Waiting for INDI device to become available..."

--- a/scripts/integration-entrypoint.sh
+++ b/scripts/integration-entrypoint.sh
@@ -16,7 +16,7 @@ echo "[integration] Waiting for INDI device to become available..."
 ready=false
 for _ in $(seq 1 30); do
   if indi_getprop -1 -t 1 "Telescope Simulator.CONNECTION.CONNECT" 2>/dev/null \
-     | grep -q "Telescope Simulator"; then
+     | grep -q "Off"; then
     ready=true
     break
   fi

--- a/scripts/integration-entrypoint.sh
+++ b/scripts/integration-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cleanup() {
+  if [[ -n "${INDI_PID:-}" ]]; then
+    kill "$INDI_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+echo "[integration] Starting indiserver with telescope simulator..."
+indiserver indi_simulator_telescope &
+INDI_PID=$!
+
+echo "[integration] Waiting for INDI device to become available..."
+ready=false
+for _ in $(seq 1 30); do
+  if indi_getprop -1 -t 1 "Telescope Simulator.CONNECTION.CONNECT" 2>/dev/null \
+     | grep -q "Telescope Simulator"; then
+    ready=true
+    break
+  fi
+  sleep 0.5
+done
+
+if [[ "$ready" != "true" ]]; then
+  echo "[integration] ERROR: Telescope Simulator did not appear within 15 seconds"
+  exit 1
+fi
+
+echo "[integration] INDI simulator ready."
+echo "[integration] Running: uv run pytest $*"
+exec uv run pytest "$@"

--- a/tests/indi/test_client.py
+++ b/tests/indi/test_client.py
@@ -1,0 +1,93 @@
+from unittest.mock import patch
+
+from astrolabe.indi.client import IndiClient
+
+
+def _make_client() -> IndiClient:
+    return IndiClient(host="127.0.0.1", port=7624)
+
+
+class TestSnapshot:
+    def test_parses_multiline_output(self):
+        stdout = (
+            "Telescope Simulator.EQUATORIAL_EOD_COORD.RA=6.0\n"
+            "Telescope Simulator.EQUATORIAL_EOD_COORD.DEC=45.0\n"
+            "Telescope Simulator.EQUATORIAL_EOD_COORD._STATE=Ok\n"
+            "Telescope Simulator.TELESCOPE_TRACK_STATE.TRACK_ON=On\n"
+            "Telescope Simulator.TELESCOPE_TRACK_STATE._STATE=Idle\n"
+        )
+        client = _make_client()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = stdout
+            mock_run.return_value.returncode = 0
+
+            result = client.snapshot("Telescope Simulator")
+
+        assert result == {
+            "Telescope Simulator.EQUATORIAL_EOD_COORD.RA": "6.0",
+            "Telescope Simulator.EQUATORIAL_EOD_COORD.DEC": "45.0",
+            "Telescope Simulator.EQUATORIAL_EOD_COORD._STATE": "Ok",
+            "Telescope Simulator.TELESCOPE_TRACK_STATE.TRACK_ON": "On",
+            "Telescope Simulator.TELESCOPE_TRACK_STATE._STATE": "Idle",
+        }
+
+    def test_returns_empty_dict_on_no_output(self):
+        client = _make_client()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = ""
+            mock_run.return_value.returncode = 1
+
+            result = client.snapshot("Telescope Simulator")
+
+        assert result == {}
+
+    def test_skips_malformed_lines(self):
+        stdout = (
+            "Telescope Simulator.FOO.BAR=baz\n"
+            "garbage line with no equals\n"
+            "Telescope Simulator.X.Y=z\n"
+        )
+        client = _make_client()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = stdout
+            mock_run.return_value.returncode = 0
+
+            result = client.snapshot("Telescope Simulator")
+
+        assert result == {
+            "Telescope Simulator.FOO.BAR": "baz",
+            "Telescope Simulator.X.Y": "z",
+        }
+
+    def test_value_containing_equals_sign(self):
+        stdout = "Device.PROP.ELEM=val=ue\n"
+        client = _make_client()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = stdout
+            mock_run.return_value.returncode = 0
+
+            result = client.snapshot("Device")
+
+        assert result == {"Device.PROP.ELEM": "val=ue"}
+
+    def test_passes_correct_args_to_subprocess(self):
+        client = IndiClient(host="10.0.0.1", port=9999)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = ""
+            mock_run.return_value.returncode = 0
+
+            client.snapshot("MyMount", timeout_s=5.0)
+
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert args == [
+            "indi_getprop",
+            "-h",
+            "10.0.0.1",
+            "-p",
+            "9999",
+            "-t",
+            "5.0",
+            "MyMount.*.*",
+            "MyMount.*._STATE",
+        ]

--- a/tests/mount/test_indi_mount.py
+++ b/tests/mount/test_indi_mount.py
@@ -251,33 +251,16 @@ def test_slew_to_wraps_ra_jnow(mount):
 
 def test_get_state_jnow(mount):
     mount._connected = True
+    snap = {
+        "Telescope Simulator.EQUATORIAL_EOD_COORD.RA": "6.0",
+        "Telescope Simulator.EQUATORIAL_EOD_COORD.DEC": "45.0",
+        "Telescope Simulator.EQUATORIAL_EOD_COORD._STATE": "Ok",
+        "Telescope Simulator.TELESCOPE_TRACK_STATE.TRACK_ON": "On",
+    }
     with (
-        patch("astrolabe.mount.indi.IndiClient.has_prop") as mock_has_prop,
-        patch("astrolabe.mount.indi.IndiClient.getprop_value") as mock_getprop,
-        patch("astrolabe.mount.indi.IndiClient.getprop_state") as mock_getprop_state,
+        patch("astrolabe.mount.indi.IndiClient.snapshot", return_value=snap),
         patch("astrolabe.mount.indi.jnow_to_icrs") as mock_jnow_to_icrs,
     ):
-
-        def has_prop_mock(prop):
-            if "EQUATORIAL_EOD_COORD" in prop:
-                return True
-            if "TELESCOPE_TRACK_STATE.TRACK_ON" in prop:
-                return True
-            return False
-
-        mock_has_prop.side_effect = has_prop_mock
-
-        def getprop_mock(prop):
-            if "EQUATORIAL_EOD_COORD.RA" in prop:
-                return "6.0"
-            if "EQUATORIAL_EOD_COORD.DEC" in prop:
-                return "45.0"
-            if "TRACK_ON" in prop:
-                return "On"
-            return ""
-
-        mock_getprop.side_effect = getprop_mock
-        mock_getprop_state.return_value = "Ok"
         mock_jnow_to_icrs.return_value = (math.pi / 2, math.pi / 4)
 
         state = mount.get_state()
@@ -287,77 +270,35 @@ def test_get_state_jnow(mount):
         assert math.isclose(state.ra_rad, math.pi / 2)
         assert math.isclose(state.dec_rad, math.pi / 4)
         assert state.slewing is False
-        mock_getprop_state.assert_called_once_with(
-            "Telescope Simulator.EQUATORIAL_EOD_COORD"
-        )
 
 
 def test_get_state_detects_slewing(mount):
     mount._connected = True
+    snap = {
+        "Telescope Simulator.EQUATORIAL_EOD_COORD.RA": "6.0",
+        "Telescope Simulator.EQUATORIAL_EOD_COORD.DEC": "45.0",
+        "Telescope Simulator.EQUATORIAL_EOD_COORD._STATE": "Busy",
+    }
     with (
-        patch("astrolabe.mount.indi.IndiClient.has_prop") as mock_has_prop,
-        patch("astrolabe.mount.indi.IndiClient.getprop_value") as mock_getprop,
-        patch("astrolabe.mount.indi.IndiClient.getprop_state") as mock_getprop_state,
+        patch("astrolabe.mount.indi.IndiClient.snapshot", return_value=snap),
         patch("astrolabe.mount.indi.jnow_to_icrs") as mock_jnow_to_icrs,
     ):
-
-        def has_prop_mock(prop):
-            if "EQUATORIAL_EOD_COORD" in prop:
-                return True
-            return False
-
-        mock_has_prop.side_effect = has_prop_mock
-
-        def getprop_mock(prop):
-            if "EQUATORIAL_EOD_COORD.RA" in prop:
-                return "6.0"
-            if "EQUATORIAL_EOD_COORD.DEC" in prop:
-                return "45.0"
-            return ""
-
-        mock_getprop.side_effect = getprop_mock
-        mock_getprop_state.return_value = "Busy"
         mock_jnow_to_icrs.return_value = (math.pi / 2, math.pi / 4)
 
         state = mount.get_state()
 
         assert state.slewing is True
-        mock_getprop_state.assert_called_once_with(
-            "Telescope Simulator.EQUATORIAL_EOD_COORD"
-        )
 
 
 def test_get_state_j2000(mount):
     mount._connected = True
-    with (
-        patch("astrolabe.mount.indi.IndiClient.has_prop") as mock_has_prop,
-        patch("astrolabe.mount.indi.IndiClient.getprop_value") as mock_getprop,
-        patch("astrolabe.mount.indi.IndiClient.getprop_state") as mock_getprop_state,
-    ):
-
-        def has_prop_mock(prop):
-            if "EQUATORIAL_EOD_COORD" in prop:
-                return False
-            if "EQUATORIAL_COORD" in prop:
-                return True
-            if "TELESCOPE_TRACK_STATE.TRACK_ON" in prop:
-                return True
-            return False
-
-        mock_has_prop.side_effect = has_prop_mock
-
-        def getprop_mock(prop):
-            if "EQUATORIAL_COORD.RA" in prop:
-                return "1.0"
-            if "EQUATORIAL_COORD.DEC" in prop:
-                return "2.0"
-            if "TRACK_ON" in prop:
-                return "On"
-            return ""
-
-        mock_getprop.side_effect = getprop_mock
-        mock_getprop_state.return_value = "Ok"
-
+    snap = {
+        "Telescope Simulator.EQUATORIAL_COORD.RA": "1.0",
+        "Telescope Simulator.EQUATORIAL_COORD.DEC": "2.0",
+        "Telescope Simulator.EQUATORIAL_COORD._STATE": "Ok",
+        "Telescope Simulator.TELESCOPE_TRACK_STATE.TRACK_ON": "On",
+    }
+    with patch("astrolabe.mount.indi.IndiClient.snapshot", return_value=snap):
         state = mount.get_state()
 
         assert state.connected is True
@@ -365,9 +306,6 @@ def test_get_state_j2000(mount):
         assert math.isclose(state.ra_rad, _hours_to_rad(1.0))
         assert math.isclose(state.dec_rad, _degrees_to_rad(2.0))
         assert state.slewing is False
-        mock_getprop_state.assert_called_once_with(
-            "Telescope Simulator.EQUATORIAL_COORD"
-        )
 
 
 def test_set_tracking_enables(mount):
@@ -501,8 +439,7 @@ def test_get_state_auto_connects(mount):
     with (
         patch("astrolabe.mount.indi.IndiClient.wait_for_device"),
         patch("astrolabe.mount.indi.IndiClient.setprop"),
-        patch("astrolabe.mount.indi.IndiClient.has_prop", return_value=False),
-        patch("astrolabe.mount.indi.IndiClient.getprop_value", return_value=""),
+        patch("astrolabe.mount.indi.IndiClient.snapshot", return_value={}),
         patch("astrolabe.mount.indi.time.sleep"),
     ):
         state = mount.get_state()


### PR DESCRIPTION
## Summary

Add a self-contained Docker image for running INDI mount and ASTAP solver integration tests. The container bundles all system-level dependencies that cannot be installed in a standard CI runner: INDI server/simulators, ASTAP plate solver, the D50 star database, and the Tycho-2 catalog.

## Motivation

Integration tests in `tests/mount/test_indi_mount.py` and `tests/solver/test_astap.py` require system binaries (`indiserver`, `indi_getprop`, `indi_setprop`, `astap_cli`) and large data files (~120 MB Tycho-2 catalog, ~400 MB D50 database) that are impractical to install in a regular CI job. A container makes these tests reproducible and runnable with a single `docker run`.

## Changes

| File | Description |
|---|---|
| `Dockerfile` | Multi-layer image based on `ubuntu:24.04` |
| `.dockerignore` | Excludes `.git/`, `.venv/`, `tycho2/`, and build artifacts from context |
| `scripts/integration-entrypoint.sh` | Starts `indiserver`, polls for readiness, then `exec`s pytest |
| `docs/dev/plan_integration_container.md` | Design plan and rationale |

### Dockerfile layers

1. **System packages** — `ca-certificates` installed first (needed for HTTPS), then the INDI PPA (DEB822 `.sources` with inline GPG key) and `indi-bin`, `libindi1`, `curl`, `wget`.
2. **ASTAP CLI** — downloaded as a `.deb` from SourceForge, with `dpkg`/`apt-get -f install` fallback for missing dependencies.
3. **ASTAP D50 star database** — mid-size database appropriate for the guide camera's ~2.66° FOV.
4. **Tycho-2 catalog** — downloaded inside the container via the existing `scripts/install-tycho2.sh` script (~120 MB from CDS Strasbourg).
5. **uv + Python 3.11** — `uv` installed directly from a pinned release (v0.10.4, sha256-verified), then `uv venv --python 3.11` to get a uv-managed Python 3.11 interpreter. Project dependencies installed via `uv sync --extra dev --extra tools`.
6. **Application code** — `COPY . .` (`.dockerignore` prevents overwriting the downloaded Tycho-2 data).

### Entrypoint behaviour

1. Starts `indiserver indi_simulator_telescope` in the background.
2. Polls `indi_getprop` until the Telescope Simulator device appears (15 s timeout).
3. `exec uv run pytest "$@"` — replaces the shell for clean signal handling.
4. Trap on `EXIT` kills `indiserver` on early exit (before `exec`).

## Usage

```bash
# Build
docker build -t astrolabe-integration .

# Run all integration tests
docker run --rm astrolabe-integration

# Run only mount tests
docker run --rm astrolabe-integration --integration tests/mount/

# Run only solver tests
docker run --rm astrolabe-integration --integration tests/solver/

# Verbose
docker run --rm astrolabe-integration --integration -v
```

## Design decisions

- **Single-stage build** — all dependencies are runtime; multi-stage would not reduce image size.
- **Layer ordering** — expensive, rarely-changing downloads (ASTAP, Tycho-2) are early layers; frequently-changing application code is last. This maximises cache reuse.
- **uv-managed Python** — Ubuntu 24.04 ships Python 3.12; the project requires `>=3.11`. Using `uv venv --python 3.11` lets uv download and manage the exact interpreter without relying on system packages or deadsnakes PPA.
- **No `USER` switch** — INDI simulators and ASTAP run as root in a disposable CI container with no secrets.
- **Pinned uv version** — installer checksum verified to ensure reproducible builds.